### PR TITLE
Build with Rviz Qt version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,6 @@ find_package(Boost REQUIRED system filesystem)
 # Ogre
 pkg_check_modules(OGRE OGRE)
 
-# Qt Stuff
-find_package(Qt4 REQUIRED)
-include(${QT_USE_FILE})
-add_definitions(-DQT_NO_KEYWORDS)
-
 find_package(OpenGL REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -21,15 +16,38 @@ find_package(catkin REQUIRED COMPONENTS
  view_controller_msgs
 )
 
+if(DEFINED rviz_QT_VERSION)
+if(rviz_QT_VERSION VERSION_LESS "5")
+  message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
+  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
+  ## pull in all required include dirs, define QT_LIBRARIES, etc.
+  include(${QT_USE_FILE})
+
+  
+  qt4_wrap_cpp(MOC_FILES
+    include/${PROJECT_NAME}/rviz_animated_view_controller.h
+  )
+else()
+  message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
+  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+  ## make target_link_libraries(${QT_LIBRARIES}) pull in all required dependencies
+  set(QT_LIBRARIES Qt5::Widgets)
+
+  qt5_wrap_cpp(MOC_FILES
+    include/${PROJECT_NAME}/rviz_animated_view_controller.h
+  )
+endif()
+else()
+  message(FATAL_ERROR "Could not detect Rviz Qt version")
+endif()
+
+add_definitions(-DQT_NO_KEYWORDS)
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS view_controller_msgs
   )
-
-qt4_wrap_cpp(MOC_FILES
-  include/${PROJECT_NAME}/rviz_animated_view_controller.h
-)
 
 include_directories(include
                     ${catkin_INCLUDE_DIRS}

--- a/plugin_description.xml
+++ b/plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="librviz_animated_view_controller">
+<library path="lib/librviz_animated_view_controller">
   <class name="rviz_animated_view_controller/Animated" type="rviz_animated_view_controller::AnimatedViewController" base_class_type="rviz::ViewController">
     <description>
       A view controller for Rviz that allows message API control, smooth view transitions, and switchable Orbit/FPS interaction.


### PR DESCRIPTION
Detects which version of Qt Rviz was built with.

Working on:
kinetic Qt5, mac os x
indigo Qt4, Ubuntu 14.04