### PR TITLE
Add support for camera trajectories messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(OpenGL REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
  rviz
  pluginlib
+ std_msgs
  view_controller_msgs
 )
 
@@ -46,7 +47,7 @@ add_definitions(-DQT_NO_KEYWORDS)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS view_controller_msgs
+  CATKIN_DEPENDS std_msgs view_controller_msgs
   )
 
 include_directories(include

--- a/include/rviz_animated_view_controller/rviz_animated_view_controller.h
+++ b/include/rviz_animated_view_controller/rviz_animated_view_controller.h
@@ -170,8 +170,17 @@ protected:  //methods
 
   void cameraPlacementCallback(const view_controller_msgs::CameraPlacementConstPtr &cp_ptr);
   //void cameraPlacementTrajectoryCallback(const view_controller_msgs::CameraPlacementTrajectoryConstPtr &cptptr);
-  void transformCameraPlacementToAttachedFrame(view_controller_msgs::CameraPlacement &cp);
-
+  
+  /** @brief Transforms the camera defined by eye, focus and up into the attached frame.
+   *
+   * @param[in,out] eye     position of the camera.
+   * @param[in,out] focus   focus point of the camera.
+   * @param[in,out] up      vector pointing up from the camera.
+   */
+  void transformCameraToAttachedFrame(geometry_msgs::PointStamped& eye,
+                                      geometry_msgs::PointStamped& focus,
+                                      geometry_msgs::Vector3Stamped& up);
+  
   //void setUpVectorPropertyModeDependent( const Ogre::Vector3 &vector );
 
   void setPropertiesFromCamera( Ogre::Camera* source_camera );

--- a/include/rviz_animated_view_controller/rviz_animated_view_controller.h
+++ b/include/rviz_animated_view_controller/rviz_animated_view_controller.h
@@ -39,6 +39,8 @@
 #include <ros/subscriber.h>
 #include <ros/ros.h>
 
+#include <std_msgs/Bool.h>
+
 #include <view_controller_msgs/CameraMovement.h>
 #include <view_controller_msgs/CameraPlacement.h>
 #include <view_controller_msgs/CameraTrajectory.h>
@@ -99,6 +101,8 @@ public:
 
   AnimatedViewController();
   virtual ~AnimatedViewController();
+
+  void initializePublishers();
 
   /** @brief Do subclass-specific initialization.  Called by
    * ViewController::initialize after context_ and camera_ are set.
@@ -328,6 +332,8 @@ protected:    //members
   
   ros::Subscriber placement_subscriber_;
   ros::Subscriber trajectory_subscriber_;
+
+  ros::Publisher finished_animation_publisher_;
 
   bool render_frame_by_frame_;
   int target_fps_;

--- a/include/rviz_animated_view_controller/rviz_animated_view_controller.h
+++ b/include/rviz_animated_view_controller/rviz_animated_view_controller.h
@@ -32,12 +32,16 @@
 #ifndef RVIZ_ANIMATED_VIEW_CONTROLLER_H
 #define RVIZ_ANIMATED_VIEW_CONTROLLER_H
 
+#include <boost/circular_buffer.hpp>
+
 #include "rviz/view_controller.h"
 
 #include <ros/subscriber.h>
 #include <ros/ros.h>
 
-#include "view_controller_msgs/CameraPlacement.h"
+#include <view_controller_msgs/CameraMovement.h>
+#include <view_controller_msgs/CameraPlacement.h>
+#include <view_controller_msgs/CameraTrajectory.h>
 
 #include <OGRE/OgreVector3.h>
 #include <OGRE/OgreQuaternion.h>
@@ -65,6 +69,33 @@ public:
 
   enum { TRANSITION_LINEAR = 0,
          TRANSITION_SPHERICAL};
+
+  struct OgreCameraMovement
+  {
+    OgreCameraMovement(){};
+
+    OgreCameraMovement(const Ogre::Vector3& eye,
+                       const Ogre::Vector3& focus,
+                       const Ogre::Vector3& up,
+                       const ros::Duration& transition_duration,
+                       const uint8_t interpolation_speed)
+      : eye(eye)
+        , focus(focus)
+        , up(up)
+        , transition_duration(transition_duration)
+        , interpolation_speed(interpolation_speed)
+    {
+    }
+
+    Ogre::Vector3 eye;
+    Ogre::Vector3 focus;
+    Ogre::Vector3 up;
+
+    ros::Duration transition_duration;
+    uint8_t interpolation_speed;
+  };
+
+  typedef boost::circular_buffer<OgreCameraMovement> BufferCamMovements;
 
   AnimatedViewController();
   virtual ~AnimatedViewController();
@@ -153,6 +184,42 @@ protected:  //methods
    * is active. Override with code that needs to run repeatedly. */
   virtual void update(float dt, float ros_dt);
 
+  /** @brief Returns true if buffer contains at least one start and end pose needed for one movement. */
+  bool isMovementAvailable(){ return cam_movements_buffer_.size() >= 2; };
+
+  /** @brief Computes the fraction of time we already used for the current movement. 
+   * 
+   * @params[in] transition_duration    total duration of the current movement.
+   * 
+   * @returns Relative progress in time as a float between 0 and 1.
+   */
+  double computeRelativeProgressInTime(const ros::Duration& transition_duration);
+  
+  /** @brief Convert the relative progress in time to the corresponding relative progress in space wrt. the interpolation speed profile.
+   *
+   * Example: 
+   *   The camera has to move from point A to point B in a duration D. 
+   *   The camera should accelerate slowly and arrive at full speed - RISING speed profile. 
+   *   At exactly half of the duration D the camera wouldn't be right in the middle between A and B, because it needed 
+   *   time to accelerate. 
+   *   This method converts the relative progress in time specified by a number between zero and one, to the relative
+   *   progress in space as a number between zero and one. 
+   *   
+   * Interpolation speed profiles:
+   * RISING    = 0 # Speed of the camera rises smoothly - resembles the first quarter of a sinus wave.
+   * DECLINING = 1 # Speed of the camera declines smoothly - resembles the second quarter of a sinus wave.
+   * FULL      = 2 # Camera is always at full speed - depending on transition_duration.
+   * WAVE      = 3 # RISING and DECLINING concatenated in one movement.
+   * 
+   * @params[in] relative_progress_in_time  the relative progress in time, between 0 and 1.
+   * @params[in] interpolation_speed        speed profile.
+   * 
+   * @returns relative progress in space as a float between 0 and 1.
+   */
+  float computeRelativeProgressInSpace(double relative_progress_in_time,
+                                       uint8_t interpolation_speed);
+  void prepareNextMovement(const ros::Duration& previous_transition_duration);
+  
   /** @brief Convenience function; connects the signals/slots for position properties. */
   void connectPositionProperties();
 
@@ -169,7 +236,12 @@ protected:  //methods
   void updateAttachedSceneNode();
 
   void cameraPlacementCallback(const view_controller_msgs::CameraPlacementConstPtr &cp_ptr);
-  //void cameraPlacementTrajectoryCallback(const view_controller_msgs::CameraPlacementTrajectoryConstPtr &cptptr);
+  
+  /** @brief Initiate camera motion from incoming CameraTrajectory.
+   *
+   * @param[in] ct_ptr  incoming CameraTrajectory msg.
+   */
+  void cameraTrajectoryCallback(const view_controller_msgs::CameraTrajectoryConstPtr& ct_ptr);
   
   /** @brief Transforms the camera defined by eye, focus and up into the attached frame.
    *
@@ -185,9 +257,19 @@ protected:  //methods
 
   void setPropertiesFromCamera( Ogre::Camera* source_camera );
 
-  /** @brief Begins a camera movement animation to the given goal points. */
-  void beginNewTransition(const Ogre::Vector3 &eye, const Ogre::Vector3 &focus, const Ogre::Vector3 &up,
-                          const ros::Duration &transition_time);
+  /** @brief Begins a camera movement animation to the given goal point.
+   *
+   * @param[in] eye                     goal position of camera.
+   * @param[in] focus                   goal focus point of camera.
+   * @param[in] up                      goal vector of camera pointing up.
+   * @param[in] transition_duration     duration needed for transition.
+   * @param[in] interpolation_speed     the interpolation speed profile.
+   */
+  void beginNewTransition(const Ogre::Vector3& eye,
+                          const Ogre::Vector3& focus,
+                          const Ogre::Vector3& up,
+                          ros::Duration transition_duration,
+                          uint8_t interpolation_speed = view_controller_msgs::CameraMovement::WAVE);
 
   /** @brief Cancels any currently active camera movement. */
   void cancelTransition();
@@ -221,7 +303,7 @@ protected:    //members
   rviz::FloatProperty* default_transition_time_property_; ///< A default time for any animation requests.
 
   rviz::RosTopicProperty* camera_placement_topic_property_;
-//  rviz::RosTopicProperty* camera_placement_trajectory_topic_property_;
+  rviz::RosTopicProperty* camera_trajectory_topic_property_;
 
   rviz::TfFrameProperty* attached_frame_property_;
   Ogre::SceneNode* attached_scene_node_;
@@ -231,20 +313,16 @@ protected:    //members
 
   // Variables used during animation
   bool animate_;
-  Ogre::Vector3 start_position_, goal_position_;
-  Ogre::Vector3 start_focus_, goal_focus_;
-  Ogre::Vector3 start_up_, goal_up_;
-  ros::Time trajectory_start_time_;
-  ros::Time transition_start_time_;
-  ros::Duration current_transition_duration_;
+  ros::WallTime transition_start_time_;
+  BufferCamMovements cam_movements_buffer_;
 
   rviz::Shape* focal_shape_;    ///< A small ellipsoid to show the focus point.
   bool dragging_;         ///< A flag indicating the dragging state of the mouse.
 
   QCursor interaction_disabled_cursor_;         ///< A cursor for indicating mouse interaction is disabled.
   
-//  ros::Subscriber trajectory_subscriber_;
   ros::Subscriber placement_subscriber_;
+  ros::Subscriber trajectory_subscriber_;
 
 };
 

--- a/include/rviz_animated_view_controller/rviz_animated_view_controller.h
+++ b/include/rviz_animated_view_controller/rviz_animated_view_controller.h
@@ -189,6 +189,9 @@ protected:  //methods
 
   /** @brief Computes the fraction of time we already used for the current movement. 
    * 
+   * If we are rendering frame by frame we compute the passed time counting the frames we already rendered.
+   * Dividing by the total number of frames we want to render for the current transition results in the progress.
+   * 
    * @params[in] transition_duration    total duration of the current movement.
    * 
    * @returns Relative progress in time as a float between 0 and 1.
@@ -218,6 +221,8 @@ protected:  //methods
    */
   float computeRelativeProgressInSpace(double relative_progress_in_time,
                                        uint8_t interpolation_speed);
+
+  /** @brief Updates the transition_start_time_ and resets the rendered_frames_counter_ for next movement. */
   void prepareNextMovement(const ros::Duration& previous_transition_duration);
   
   /** @brief Convenience function; connects the signals/slots for position properties. */
@@ -324,6 +329,9 @@ protected:    //members
   ros::Subscriber placement_subscriber_;
   ros::Subscriber trajectory_subscriber_;
 
+  bool render_frame_by_frame_;
+  int target_fps_;
+  int rendered_frames_counter_;
 };
 
 }  // namespace rviz_animated_view_controller

--- a/package.xml
+++ b/package.xml
@@ -14,10 +14,12 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>view_controller_msgs</build_depend>
   <build_depend>rviz</build_depend>
   <build_depend>pluginlib</build_depend>
 
+  <run_depend>std_msgs</run_depend>
   <run_depend>view_controller_msgs</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>pluginlib</run_depend>

--- a/src/rviz_animated_view_controller.cpp
+++ b/src/rviz_animated_view_controller.cpp
@@ -92,7 +92,10 @@ static inline void vectorOgreToMsg(const Ogre::Vector3 &o, geometry_msgs::Vector
 
 
 AnimatedViewController::AnimatedViewController()
-  : nh_(""), animate_(false), dragging_( false )
+  : nh_("")
+    , cam_movements_buffer_(100)
+    , animate_(false)
+    , dragging_(false)
 {
   interaction_disabled_cursor_ = makeIconCursor( "package://rviz/icons/forbidden.svg" );
 
@@ -130,9 +133,11 @@ AnimatedViewController::AnimatedViewController()
                                                           QString::fromStdString(ros::message_traits::datatype<view_controller_msgs::CameraPlacement>() ),
                                                           "Topic for CameraPlacement messages", this, SLOT(updateTopics()));
 
-//  camera_placement_trajectory_topic_property_ = new RosTopicProperty("Trajectory Topic", "/rviz/camera_placement_trajectory",
-//                                                          QString::fromStdString(ros::message_traits::datatype<view_controller_msgs::CameraPlacementTrajectory>() ),
-//                                                          "Topic for CameraPlacementTrajectory messages", this, SLOT(updateTopics()));
+  camera_trajectory_topic_property_ = new RosTopicProperty("Trajectory Topic", "/rviz/camera_trajectory",
+                                                           QString::fromStdString(
+                                                             ros::message_traits::datatype<view_controller_msgs::CameraTrajectory>()),
+                                                           "Topic for CameraTrajectory messages", this,
+                                                           SLOT(updateTopics()));
 }
 
 AnimatedViewController::~AnimatedViewController()
@@ -143,12 +148,13 @@ AnimatedViewController::~AnimatedViewController()
 
 void AnimatedViewController::updateTopics()
 {
-//  trajectory_subscriber_ = nh_.subscribe<view_controller_msgs::CameraPlacementTrajectory>
-//                              (camera_placement_trajectory_topic_property_->getStdString(), 1,
-//                              boost::bind(&AnimatedViewController::cameraPlacementTrajectoryCallback, this, _1));
   placement_subscriber_  = nh_.subscribe<view_controller_msgs::CameraPlacement>
                               (camera_placement_topic_property_->getStdString(), 1,
                               boost::bind(&AnimatedViewController::cameraPlacementCallback, this, _1));
+  
+  trajectory_subscriber_ = nh_.subscribe<view_controller_msgs::CameraTrajectory>
+                                (camera_trajectory_topic_property_->getStdString(), 1,
+                                 boost::bind(&AnimatedViewController::cameraTrajectoryCallback, this, _1));
 }
 
 void AnimatedViewController::onInitialize()
@@ -503,31 +509,35 @@ void AnimatedViewController::transitionFrom( ViewController* previous_view )
   }
 }
 
-void AnimatedViewController::beginNewTransition(const Ogre::Vector3 &eye, const Ogre::Vector3 &focus, const Ogre::Vector3 &up,
-                                            const ros::Duration &transition_time)
+void AnimatedViewController::beginNewTransition(const Ogre::Vector3 &eye, 
+                                                const Ogre::Vector3 &focus, 
+                                                const Ogre::Vector3 &up,
+                                                ros::Duration transition_duration,
+                                                uint8_t interpolation_speed)
 {
-  if(ros::Duration(transition_time).isZero())
-  {
-    eye_point_property_->setVector(eye);
-    focus_point_property_->setVector(focus);
-    up_vector_property_->setVector(up);
-    distance_property_->setFloat(getDistanceFromCameraToFocalPoint());
+  if(transition_duration.toSec() < 0.0)
     return;
+
+  // convert positional jumps to very fast movements to prevent numerical problems 
+  if(transition_duration.isZero())
+    transition_duration = ros::Duration(0.001);
+
+  // if the buffer is empty we set the first element in it to the current camera pose
+  if(cam_movements_buffer_.empty())
+  {
+    transition_start_time_ = ros::WallTime::now();
+
+    cam_movements_buffer_.push_back(std::move(OgreCameraMovement(eye_point_property_->getVector(),
+                                                                 focus_point_property_->getVector(),
+                                                                 up_vector_property_->getVector(),
+                                                                 ros::Duration(0.001),
+                                                                 interpolation_speed))); // interpolation_speed doesn't make a difference for very short times
   }
 
-  start_position_ = eye_point_property_->getVector();
-  goal_position_ = eye;
+  if(cam_movements_buffer_.full())
+    cam_movements_buffer_.set_capacity(cam_movements_buffer_.capacity() + 20);
 
-  start_focus_ = focus_point_property_->getVector();
-  goal_focus_ = focus;
-
-//  start_up_ = fixed_up_property_->getBool() ? (Ogre::Vector3::UNIT_Z) : getOrientation().yAxis();
-//  goal_up_ =  fixed_up_property_->getBool() ? (Ogre::Vector3::UNIT_Z) : up;
-  start_up_ = up_vector_property_->getVector();
-  goal_up_ =  up;
-
-  current_transition_duration_ = ros::Duration(transition_time);
-  transition_start_time_ = ros::Time::now();
+  cam_movements_buffer_.push_back(std::move(OgreCameraMovement(eye, focus, up, transition_duration, interpolation_speed)));
 
   animate_ = true;
 }
@@ -535,6 +545,8 @@ void AnimatedViewController::beginNewTransition(const Ogre::Vector3 &eye, const 
 void AnimatedViewController::cancelTransition()
 {
   animate_ = false;
+
+  cam_movements_buffer_.clear();
 }
 
 void AnimatedViewController::cameraPlacementCallback(const CameraPlacementConstPtr &cp_ptr)
@@ -574,41 +586,52 @@ void AnimatedViewController::cameraPlacementCallback(const CameraPlacementConstP
   }
 }
 
-//void AnimatedViewController::cameraPlacementTrajectoryCallback(const CameraPlacementTrajectoryConstPtr &cptptr)
-//{
-//  CameraPlacementTrajectory cpt = *cptptr;
-//  ROS_DEBUG_STREAM("Received a camera placement trajectory request! \n" << cpt);
-  
-//  // Handle control parameters
-//  mouse_enabled_property_->setBool( cpt.interaction_enabled );
-//  fixed_up_property_->setBool( !cpt.allow_free_yaw_axis );
-//  if(cpt.mouse_interaction_mode != cpt.NO_CHANGE)
-//  {
-//    std::string name = "";
-//    if(cpt.mouse_interaction_mode == cpt.ORBIT) name = MODE_ORBIT;
-//    else if(cpt.mouse_interaction_mode == cpt.FPS) name = MODE_FPS;
-//    interaction_mode_property_->setStdString(name);
-//  }
+void AnimatedViewController::cameraTrajectoryCallback(const view_controller_msgs::CameraTrajectoryConstPtr& ct_ptr)
+{
+  view_controller_msgs::CameraTrajectory ct = *ct_ptr;
 
-//  // TODO should transform the interpolated positions (later), or transform info will only reflect the TF tree state at the beginning...
-//  for(size_t i = 0; i<cpt.placements.size(); i++)
-//  {
-//    transformCameraPlacementToAttachedFrame(cpt.placements[i]);
-//  }
+  if(ct.trajectory.empty())
+    return;
 
-//  // For now, just transition to the first placement until we put in the capacity for a trajectory
-//  CameraPlacement cp = cpt.placements[0];
-//  if(cp.target_frame != "")
-//  {
-//    attached_frame_property_->setStdString(cp.target_frame);
-//    updateAttachedFrame();
-//  }
-//  Ogre::Vector3 eye = vectorFromMsg(cp.eye.point);
-//  Ogre::Vector3 focus = vectorFromMsg(cp.focus.point);
-//  Ogre::Vector3 up = vectorFromMsg(cp.up.vector);
+  // Handle control parameters
+  mouse_enabled_property_->setBool(!ct.interaction_disabled);
+  fixed_up_property_->setBool(!ct.allow_free_yaw_axis);
+  if(ct.mouse_interaction_mode != view_controller_msgs::CameraTrajectory::NO_CHANGE)
+  {
+    std::string name = "";
+    if(ct.mouse_interaction_mode == view_controller_msgs::CameraTrajectory::ORBIT)
+      name = MODE_ORBIT;
+    else if(ct.mouse_interaction_mode == view_controller_msgs::CameraTrajectory::FPS)
+      name = MODE_FPS;
+    interaction_mode_property_->setStdString(name);
+  }
 
-//  beginNewTransition(eye, focus, up, cp.time_from_start);
-//}
+
+  for(auto& cam_movement : ct.trajectory)
+  {
+    if(cam_movement.transition_duration.toSec() >= 0.0)
+    {
+      if(ct.target_frame != "")
+      {
+        attached_frame_property_->setStdString(ct.target_frame);
+        updateAttachedFrame();
+      }
+
+      transformCameraToAttachedFrame(cam_movement.eye,
+                                     cam_movement.focus,
+                                     cam_movement.up);
+
+      Ogre::Vector3 eye = vectorFromMsg(cam_movement.eye.point);
+      Ogre::Vector3 focus = vectorFromMsg(cam_movement.focus.point);
+      Ogre::Vector3 up = vectorFromMsg(cam_movement.up.vector);
+      beginNewTransition(eye, focus, up, cam_movement.transition_duration, cam_movement.interpolation_speed);
+    }
+    else
+    {
+      ROS_WARN("Transition duration of camera movement is below zero. Skipping that movement.");
+    }
+  }
+}
 
 void AnimatedViewController::transformCameraToAttachedFrame(geometry_msgs::PointStamped& eye,
                                                             geometry_msgs::PointStamped& focus,
@@ -636,7 +659,6 @@ void AnimatedViewController::transformCameraToAttachedFrame(geometry_msgs::Point
   focus.header.frame_id = attached_frame_property_->getStdString();
   up.header.frame_id = attached_frame_property_->getStdString();
 }
-
 
 // We must assume that this point is in the Rviz Fixed frame since it came from Rviz...
 void AnimatedViewController::lookAt( const Ogre::Vector3& point )
@@ -673,23 +695,27 @@ void AnimatedViewController::update(float dt, float ros_dt)
 {
   updateAttachedSceneNode();
 
-  if(animate_)
+  if(animate_ && isMovementAvailable())
   {
-    ros::Duration time_from_start = ros::Time::now() - transition_start_time_;
-    float fraction = time_from_start.toSec()/current_transition_duration_.toSec();
+    auto start = cam_movements_buffer_.begin();
+    auto goal = ++(cam_movements_buffer_.begin());
+
+    double relative_progress_in_time = computeRelativeProgressInTime(goal->transition_duration);
+
     // make sure we get all the way there before turning off
-    if(fraction > 1.0f)
+    bool finished_current_movement = false;
+    if(relative_progress_in_time >= 1.0)
     {
-      fraction = 1.0f;
-      animate_ = false;
+      relative_progress_in_time = 1.0;
+      finished_current_movement = true;
     }
 
-    // TODO remap progress to progress_out, which can give us a new interpolation profile.
-    float progress = 0.5*(1-cos(fraction*M_PI));
+    float relative_progress_in_space = computeRelativeProgressInSpace(relative_progress_in_time,
+                                                                      goal->interpolation_speed);
 
-    Ogre::Vector3 new_position = start_position_ + progress*(goal_position_ - start_position_);
-    Ogre::Vector3 new_focus  = start_focus_ + progress*(goal_focus_ - start_focus_);
-    Ogre::Vector3 new_up  = start_up_ + progress*(goal_up_ - start_up_);
+    Ogre::Vector3 new_position = start->eye + relative_progress_in_space * (goal->eye - start->eye);
+    Ogre::Vector3 new_focus = start->focus + relative_progress_in_space * (goal->focus - start->focus);
+    Ogre::Vector3 new_up = start->up + relative_progress_in_space * (goal->up - start->up);
 
     disconnectPositionProperties();
     eye_point_property_->setVector( new_position );
@@ -701,8 +727,48 @@ void AnimatedViewController::update(float dt, float ros_dt)
     // This needs to happen so that the camera orientation will update properly when fixed_up_property == false
     camera_->setFixedYawAxis(true, reference_orientation_ * up_vector_property_->getVector());
     camera_->setDirection(reference_orientation_ * (focus_point_property_->getVector() - eye_point_property_->getVector()));
+
+    if(finished_current_movement)
+    {
+      // delete current start element in buffer
+      cam_movements_buffer_.pop_front();
+
+      if(isMovementAvailable())
+        prepareNextMovement(goal->transition_duration);
+      else
+        cancelTransition();
+    }
   }
   updateCamera();
+}
+
+double AnimatedViewController::computeRelativeProgressInTime(const ros::Duration& transition_duration)
+{
+  ros::WallDuration duration_from_start = ros::WallTime::now() - transition_start_time_;
+  double relative_progress_in_time = duration_from_start.toSec() / transition_duration.toSec();
+  return relative_progress_in_time;
+}
+
+float AnimatedViewController::computeRelativeProgressInSpace(double relative_progress_in_time,
+                                                             uint8_t interpolation_speed)
+{
+  switch(interpolation_speed)
+  {
+    case view_controller_msgs::CameraMovement::RISING:
+      return 1.f - static_cast<float>(cos(relative_progress_in_time * M_PI_2));
+    case view_controller_msgs::CameraMovement::DECLINING:
+      return static_cast<float>(-cos(relative_progress_in_time * M_PI_2 + M_PI_2));
+    case view_controller_msgs::CameraMovement::FULL:
+      return static_cast<float>(relative_progress_in_time);
+    case view_controller_msgs::CameraMovement::WAVE:
+    default:
+      return 0.5f * (1.f - static_cast<float>(cos(relative_progress_in_time * M_PI)));
+  }
+}
+
+void AnimatedViewController::prepareNextMovement(const ros::Duration& previous_transition_duration)
+{
+  transition_start_time_ += ros::WallDuration(previous_transition_duration.toSec());
 }
 
 void AnimatedViewController::updateCamera()


### PR DESCRIPTION
Solving [issue](https://github.com/ros-visualization/rviz_animated_view_controller/issues/12).

[Pull request](https://github.com/ros-visualization/view_controller_msgs/pull/8) in view_controller_msgs has to be merged for this.

Adding support to send multiple consecutive goal positions in a view_controller_msgs/CameraTrajectory message.

I tried to make my additions as clean as possible, while keeping them as close as possible to the original code. 
I think it's easiest to compare the original and adapted code side by side to see the similarities best. Especially for the larger commit. 

The camera test using the demo.launch file within this package works as before. 
Old and new functionality was tested using the [rviz_cinematographer](https://github.com/AIS-Bonn/rviz_cinematographer).