### PR TITLE
Add properties showing view window size in panel

### DIFF
--- a/include/rviz_animated_view_controller/rviz_animated_view_controller.h
+++ b/include/rviz_animated_view_controller/rviz_animated_view_controller.h
@@ -183,6 +183,7 @@ protected Q_SLOTS:
   virtual void onUpPropertyChanged();
 
 protected:  //methods
+  void updateWindowSizeProperties();
 
   /** @brief Called at 30Hz by ViewManager::update() while this view
    * is active. Override with code that needs to run repeatedly. */
@@ -314,6 +315,9 @@ protected:    //members
   rviz::RosTopicProperty* camera_placement_topic_property_;
   rviz::RosTopicProperty* camera_trajectory_topic_property_;
 
+  rviz::FloatProperty* window_width_property_;            ///< The width of the rviz visualization window in pixels.
+  rviz::FloatProperty* window_height_property_;           ///< The height of the rviz visualization window in pixels.
+  
   rviz::TfFrameProperty* attached_frame_property_;
   Ogre::SceneNode* attached_scene_node_;
 

--- a/src/rviz_animated_view_controller.cpp
+++ b/src/rviz_animated_view_controller.cpp
@@ -36,6 +36,8 @@
 #include "rviz/viewport_mouse_event.h"
 #include "rviz/frame_manager.h"
 #include "rviz/geometry.h"
+#include "rviz/view_manager.h"
+#include "rviz/render_panel.h"
 #include "rviz/ogre_helpers/shape.h"
 #include "rviz/properties/float_property.h"
 #include "rviz/properties/vector_property.h"
@@ -52,6 +54,7 @@
 #include <OGRE/OgreSceneNode.h>
 #include <OGRE/OgreSceneManager.h>
 #include <OGRE/OgreCamera.h>
+#include <OGRE/OgreRenderWindow.h>
 
 namespace rviz_animated_view_controller
 {
@@ -142,6 +145,9 @@ AnimatedViewController::AnimatedViewController()
                                                            "Topic for CameraTrajectory messages", this,
                                                            SLOT(updateTopics()));
 
+  window_width_property_ = new FloatProperty("Window Width", 1000, "The width of the rviz visualization window in pixels.", this);
+  window_height_property_ = new FloatProperty("Window Height", 1000, "The height of the rviz visualization window in pixels.", this);
+  
   initializePublishers();
 }
 
@@ -181,6 +187,13 @@ void AnimatedViewController::onInitialize()
     focal_shape_->setColor(1.0f, 1.0f, 0.0f, 0.5f);
     focal_shape_->getRootNode()->setVisible(false);
 
+    updateWindowSizeProperties();
+}
+
+void AnimatedViewController::updateWindowSizeProperties()
+{
+  window_width_property_->setFloat(context_->getViewManager()->getRenderPanel()->getRenderWindow()->getWidth());
+  window_height_property_->setFloat(context_->getViewManager()->getRenderPanel()->getRenderWindow()->getHeight());
 }
 
 void AnimatedViewController::onActivate()
@@ -764,6 +777,7 @@ void AnimatedViewController::update(float dt, float ros_dt)
     }
   }
   updateCamera();
+  updateWindowSizeProperties();
 }
 
 double AnimatedViewController::computeRelativeProgressInTime(const ros::Duration& transition_duration)


### PR DESCRIPTION
Resolves issue #15.  
Addresses issue [#7](https://github.com/AIS-Bonn/rviz_cinematographer/issues/7) of the rviz_cinematographer.

Adds properties to the view panel that show the size of the view window. 
This is helps to adjust the window size to a desired format when recording animated views. 