### PR TITLE
Add publisher for the current view camera pose

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(OpenGL REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
  rviz
  pluginlib
+ geometry_msgs
  std_msgs
  view_controller_msgs
 )
@@ -47,7 +48,7 @@ add_definitions(-DQT_NO_KEYWORDS)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS std_msgs view_controller_msgs
+  CATKIN_DEPENDS geometry_msgs std_msgs view_controller_msgs
   )
 
 include_directories(include

--- a/include/rviz_animated_view_controller/rviz_animated_view_controller.h
+++ b/include/rviz_animated_view_controller/rviz_animated_view_controller.h
@@ -39,6 +39,8 @@
 #include <ros/subscriber.h>
 #include <ros/ros.h>
 
+#include <geometry_msgs/Pose.h>
+
 #include <std_msgs/Bool.h>
 
 #include <view_controller_msgs/CameraMovement.h>
@@ -130,7 +132,9 @@ public:
 
   virtual void handleMouseEvent(rviz::ViewportMouseEvent& evt);
 
-
+  /** @brief Publishes the current camera pose. */
+  void publishCameraPose();
+  
   /** @brief Calls beginNewTransition() to
       move the focus point to the point provided, assumed to be in the Rviz Fixed Frame */
   virtual void lookAt( const Ogre::Vector3& point );
@@ -333,6 +337,7 @@ protected:    //members
   ros::Subscriber placement_subscriber_;
   ros::Subscriber trajectory_subscriber_;
 
+  ros::Publisher current_camera_pose_publisher_;
   ros::Publisher finished_animation_publisher_;
 
   bool render_frame_by_frame_;

--- a/package.xml
+++ b/package.xml
@@ -14,11 +14,13 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>view_controller_msgs</build_depend>
   <build_depend>rviz</build_depend>
   <build_depend>pluginlib</build_depend>
 
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>view_controller_msgs</run_depend>
   <run_depend>rviz</run_depend>

--- a/src/rviz_animated_view_controller.cpp
+++ b/src/rviz_animated_view_controller.cpp
@@ -164,6 +164,7 @@ void AnimatedViewController::updateTopics()
 
 void AnimatedViewController::initializePublishers()
 {
+  current_camera_pose_publisher_ = nh_.advertise<geometry_msgs::Pose>("/rviz/current_camera_pose", 1);
   finished_animation_publisher_ = nh_.advertise<std_msgs::Bool>("/rviz/finished_animation", 1);
 }
 
@@ -443,8 +444,22 @@ void AnimatedViewController::handleMouseEvent(ViewportMouseEvent& event)
 
   if (moved)
   {
+    publishCameraPose();
     context_->queueRender();
   }
+}
+
+void AnimatedViewController::publishCameraPose()
+{
+  geometry_msgs::Pose cam_pose;
+  cam_pose.position.x = camera_->getPosition().x;
+  cam_pose.position.y = camera_->getPosition().y;
+  cam_pose.position.z = camera_->getPosition().z;
+  cam_pose.orientation.w = camera_->getOrientation().w;
+  cam_pose.orientation.x = camera_->getOrientation().x;
+  cam_pose.orientation.y = camera_->getOrientation().y;
+  cam_pose.orientation.z = camera_->getOrientation().z;
+  current_camera_pose_publisher_.publish(cam_pose);
 }
 
 //void AnimatedViewController::setUpVectorPropertyModeDependent( const Ogre::Vector3 &vector )
@@ -752,6 +767,8 @@ void AnimatedViewController::update(float dt, float ros_dt)
     camera_->setFixedYawAxis(true, reference_orientation_ * up_vector_property_->getVector());
     camera_->setDirection(reference_orientation_ * (focus_point_property_->getVector() - eye_point_property_->getVector()));
 
+    publishCameraPose();
+    
     if(finished_current_movement)
     {
       // delete current start element in buffer


### PR DESCRIPTION
Resolves issue #10.  
Addresses issue [#7](https://github.com/AIS-Bonn/rviz_cinematographer/issues/7) of the rviz_cinematographer.  

The pose of the rviz view camera is published as a geometry_msgs::Pose every time the camera is moved - either by mouse or by animation. 
The pose is not published when the camera does not move to not spam the network.  